### PR TITLE
Row not shown if field has null value

### DIFF
--- a/Util/Factory/Query/DoctrineBuilder.php
+++ b/Util/Factory/Query/DoctrineBuilder.php
@@ -58,7 +58,9 @@ class DoctrineBuilder implements QueryInterface
             $search_fields = array_values($this->fields);
             foreach ($search_fields as $i => $search_field)
             {
-                $queryBuilder->andWhere(" $search_field like '%{$request->get("sSearch_{$i}")}%' ");
+                if($request->get("sSearch_{$i}")){ 
+                    $queryBuilder->andWhere(" $search_field like '%{$request->get("sSearch_{$i}")}%' ");
+                }
             }
         }
     }


### PR DESCRIPTION
If the filtered field is NULL, the row will not be displayed even if the the filter box nothing is entered.
