### PR TITLE
Event to further configure datatables configuration before initialization

### DIFF
--- a/Resources/views/Main/index.html.twig
+++ b/Resources/views/Main/index.html.twig
@@ -104,6 +104,7 @@
         };
         $.extend($defaults,$js);
         $.extend($defaults,$options);
+        $('#{{id}}').trigger('datatables_init', $defaults );
         eval("var "+ "oTable_"+'{{id}}'.split('-').join('_') + "  = $('#{{id}}').dataTable($defaults)");
         $(s).on('click','.button-delete:parent',function(e){
             if (!confirm('{{ 'ali.common.confirm_delete'|trans()  }}')) {


### PR DESCRIPTION
What do you think about adding this event?

The use case is because is need to set some callbacks into the configuration, for example to set some logic in fnServerParams.

For example:

``` javascript
$('#table_id').bind('datatables_init', function(id, options){
    options.fnServerParams = function ( aoData ) {
        aoData.push( { "name" : 'anything', "value": "you may need" } );
    }
});
```

if you find it useful, i can make a pull request to configure the event name through the $this->_config['all'] and/or the twig extension. Your call there
