### PR TITLE
Second condition added for the search

### DIFF
--- a/Util/Factory/Query/DoctrineBuilder.php
+++ b/Util/Factory/Query/DoctrineBuilder.php
@@ -80,7 +80,8 @@ class DoctrineBuilder implements QueryInterface
             $search_fields = array_values($this->fields);
             foreach ($search_fields as $i => $search_field)
             {
-                if ($request->get("sSearch_{$i}") !== false)
+                $search_param = $request->get("sSearch_{$i}");
+                if ($request->get("sSearch_{$i}") !== false && !empty($search_param))
                 {
                     $queryBuilder->andWhere(" $search_field like '%{$request->get("sSearch_{$i}")}%' ");
                 }


### PR DESCRIPTION
By adding the "!== false" condition, it has created a new bug. 

Since all the search parameters are not defined as false but as empty string, the query get all the search parameters (WHERE field LIKE "%%"). With this, if there are data set as NULL in the database, these entries are not returned.
