### PR TITLE
bugfix for DoctrineBuilder

### DIFF
--- a/Util/Factory/Query/DoctrineBuilder.php
+++ b/Util/Factory/Query/DoctrineBuilder.php
@@ -171,7 +171,7 @@ class DoctrineBuilder implements QueryInterface
         {
             $selectFields = $this->fields;
             foreach($selectFields as &$field){
-                $field = $field. ' as ' . str_replace('.', '_', $field);
+                $field = $field. ' as ' . str_replace('.', '_', $field) . '_' . substr(md5(rand()), 0, 8);
             }
             $qb->select(implode(" , ", $selectFields));
         }


### PR DESCRIPTION
The bug occurs when selected 'id' field and 'id' is an '_identifier_''

```
        $datatable->setFields(
            array(
                'ID'            => 'a.id',
                'LAST UPDATED'  => 'a.last_updated',
                '_identifier_'  => 'a.id'
            )
        );
```
