### PR TITLE
[] syntax for creating array not valid in PHP5.3

### DIFF
--- a/Util/Factory/Query/DoctrineBuilder.php
+++ b/Util/Factory/Query/DoctrineBuilder.php
@@ -215,7 +215,7 @@ class DoctrineBuilder implements QueryInterface
             }
             $data[] = $d;
         }
-        return [$data, $objects];
+        return array($data, $objects);
     }
 
     /**


### PR DESCRIPTION
fixes #75
