### PR TITLE
fix typo "élement" to "élément"

### DIFF
--- a/Resources/translations/messages.fr.yml
+++ b/Resources/translations/messages.fr.yml
@@ -8,7 +8,7 @@ ali:
         sProcessing: "Traitement en cours..."
         sLengthMenu: "Afficher _MENU_ éléments"
         sZeroRecords: "Aucun élément à afficher"
-        sInfo: "Affichage de l'élement _START_ à _END_ sur _TOTAL_ éléments"
+        sInfo: "Affichage de l'élément _START_ à _END_ sur _TOTAL_ éléments"
         sInfoEmpty: "Affichage de l'élement 0 à 0 sur 0 éléments"
         sInfoFiltered: "(filtré de _MAX_ éléments au total)"
         sInfoPostFix: ""


### PR DESCRIPTION
fix typo "élement" to "élément"
