### PR TITLE
overwrite EntityManager

### DIFF
--- a/Util/Datatable.php
+++ b/Util/Datatable.php
@@ -5,7 +5,8 @@ namespace Ali\DatatableBundle\Util;
 use Symfony\Component\DependencyInjection\ContainerInterface,
     Symfony\Component\HttpFoundation\Response;
 use Doctrine\ORM\Query,
-    Doctrine\ORM\Query\Expr\Join;
+    Doctrine\ORM\Query\Expr\Join,
+    Doctrine\ORM\EntityManager;
 use Ali\DatatableBundle\Util\Factory\Query\QueryInterface,
     Ali\DatatableBundle\Util\Factory\Query\DoctrineBuilder,
     Ali\DatatableBundle\Util\Formatter\Renderer,
@@ -63,24 +64,24 @@ class Datatable
     protected static $_current_instance = NULL;
 
     /**
-     * class constructor 
-     * 
-     * @param ContainerInterface $container 
+     * class constructor
+     *
+     * @param ContainerInterface $container
      */
     public function __construct(ContainerInterface $container)
     {
         $this->_container    = $container;
         $this->_config       = $this->_container->getParameter('ali_datatable');
-        $this->_em           = $this->_container->get('doctrine.orm.entity_manager');
+        $this->setEntityManager($this->_container->get('doctrine.orm.entity_manager'));
         $this->_request      = $this->_container->get('request');
-        $this->_queryBuilder = new DoctrineBuilder($container);
+        $this->_queryBuilder = new DoctrineBuilder($container, $this->getEntityManager());
         self::$_current_instance = $this;
         $this->_applyDefaults();
     }
 
     /**
      * apply default value from datatable config
-     * 
+     *
      * @return void
      */
     protected function _applyDefaults()
@@ -94,20 +95,20 @@ class Datatable
 
     /**
      * add join
-     * 
+     *
      * @example:
-     *      ->setJoin( 
-     *              'r.event', 
-     *              'e', 
-     *              \Doctrine\ORM\Query\Expr\Join::INNER_JOIN, 
-     *              'e.name like %test%') 
-     * 
+     *      ->setJoin(
+     *              'r.event',
+     *              'e',
+     *              \Doctrine\ORM\Query\Expr\Join::INNER_JOIN,
+     *              'e.name like %test%')
+     *
      * @param string $join_field
      * @param string $alias
      * @param string $type
      * @param string $cond
-     * 
-     * @return Datatable 
+     *
+     * @return Datatable
      */
     public function addJoin($join_field, $alias, $type = Join::INNER_JOIN, $cond = '')
     {
@@ -117,10 +118,10 @@ class Datatable
 
     /**
      * execute
-     * 
+     *
      * @param int $hydration_mode
-     * 
-     * @return Response 
+     *
+     * @return Response
      */
     public function execute($hydration_mode = Query::HYDRATE_ARRAY)
     {
@@ -167,9 +168,9 @@ class Datatable
     /**
      * get datatable instance by id
      *  return current instance if null
-     * 
+     *
      * @param string $id
-     * 
+     *
      * @return Datatable .
      */
     public static function getInstance($id)
@@ -195,7 +196,7 @@ class Datatable
 
     /**
      * get entity name
-     * 
+     *
      * @return string
      */
     public function getEntityName()
@@ -205,7 +206,7 @@ class Datatable
 
     /**
      * get entity alias
-     * 
+     *
      * @return string
      */
     public function getEntityAlias()
@@ -215,7 +216,7 @@ class Datatable
 
     /**
      * get fields
-     * 
+     *
      * @return array
      */
     public function getFields()
@@ -225,7 +226,7 @@ class Datatable
 
     /**
      * get has_action
-     * 
+     *
      * @return boolean
      */
     public function getHasAction()
@@ -235,7 +236,7 @@ class Datatable
 
     /**
      * retrun true if the actions column is overridden by twig renderer
-     * 
+     *
      * @return boolean
      */
     public function getHasRendererAction()
@@ -255,7 +256,7 @@ class Datatable
 
     /**
      * get order type
-     * 
+     *
      * @return string
      */
     public function getOrderType()
@@ -267,8 +268,8 @@ class Datatable
      * create raw prototype
      *
      * @param string $type
-     * 
-     * @return PrototypeBuilder 
+     *
+     * @return PrototypeBuilder
      */
     public function getPrototype($type)
     {
@@ -277,7 +278,7 @@ class Datatable
 
     /**
      * get query builder
-     * 
+     *
      * @return QueryInterface
      */
     public function getQueryBuilder()
@@ -287,7 +288,7 @@ class Datatable
 
     /**
      * get search
-     * 
+     *
      * @return boolean
      */
     public function getSearch()
@@ -297,11 +298,11 @@ class Datatable
 
     /**
      * set entity
-     * 
+     *
      * @param type $entity_name
      * @param type $entity_alias
-     * 
-     * @return Datatable 
+     *
+     * @return Datatable
      */
     public function setEntity($entity_name, $entity_alias)
     {
@@ -311,10 +312,10 @@ class Datatable
 
     /**
      * set fields
-     * 
+     *
      * @param array $fields
-     * 
-     * @return Datatable 
+     *
+     * @return Datatable
      */
     public function setFields(array $fields)
     {
@@ -324,9 +325,9 @@ class Datatable
 
     /**
      * set has action
-     * 
+     *
      * @param type $has_action
-     * 
+     *
      * @return Datatable
      */
     public function setHasAction($has_action)
@@ -337,11 +338,11 @@ class Datatable
 
     /**
      * set order
-     * 
+     *
      * @param type $order_field
      * @param type $order_type
-     * 
-     * @return Datatable 
+     *
+     * @return Datatable
      */
     public function setOrder($order_field, $order_type)
     {
@@ -351,10 +352,10 @@ class Datatable
 
     /**
      * set fixed data
-     * 
+     *
      * @param type $data
-     * 
-     * @return Datatable 
+     *
+     * @return Datatable
      */
     public function setFixedData($data)
     {
@@ -364,8 +365,8 @@ class Datatable
 
     /**
      * set query builder
-     * 
-     * @param QueryInterface $queryBuilder 
+     *
+     * @param QueryInterface $queryBuilder
      */
     public function setQueryBuilder(QueryInterface $queryBuilder)
     {
@@ -374,9 +375,9 @@ class Datatable
 
     /**
      * set a php closure as renderer
-     * 
+     *
      * @example:
-     * 
+     *
      *  $controller_instance = $this;
      *  $datatable = $this->get('datatable')
      *       ->setEntity("AliBaseBundle:Entity", "e")
@@ -401,10 +402,10 @@ class Datatable
      *               }
      *         )
      *       ->setHasAction(true);
-     * 
+     *
      * @param \Closure $renderer
-     * 
-     * @return Datatable 
+     *
+     * @return Datatable
      */
     public function setRenderer(\Closure $renderer)
     {
@@ -414,9 +415,9 @@ class Datatable
 
     /**
      * set renderers as twig views
-     * 
+     *
      * @example: To override the actions column
-     * 
+     *
      *      ->setFields(
      *          array(
      *             "field label 1" => 'x.field1',
@@ -436,10 +437,10 @@ class Datatable
      *             ),
      *          )
      *       )
-     * 
+     *
      * @param array $renderers
-     * 
-     * @return Datatable 
+     *
+     * @return Datatable
      */
     public function setRenderers(array $renderers)
     {
@@ -458,11 +459,11 @@ class Datatable
 
     /**
      * set query where
-     * 
+     *
      * @param string $where
      * @param array  $params
-     * 
-     * @return Datatable 
+     *
+     * @return Datatable
      */
     public function setWhere($where, array $params = array())
     {
@@ -472,10 +473,10 @@ class Datatable
 
     /**
      * set query group
-     * 
+     *
      * @param string $groupbywhere
-     * 
-     * @return Datatable 
+     *
+     * @return Datatable
      */
     public function setGroupBy($groupby)
     {
@@ -485,9 +486,9 @@ class Datatable
 
     /**
      * set search
-     * 
+     *
      * @param bool $search
-     * 
+     *
      * @return Datatable
      */
     public function setSearch($search)
@@ -499,10 +500,10 @@ class Datatable
 
     /**
      * set datatable identifier
-     * 
+     *
      * @param string $id
-     * 
-     * @return Datatable 
+     *
+     * @return Datatable
      */
     public function setDatatableId($id)
     {
@@ -519,7 +520,7 @@ class Datatable
 
     /**
      * get multiple
-     * 
+     *
      * @return array
      */
     public function getMultiple()
@@ -529,13 +530,13 @@ class Datatable
 
     /**
      * set multiple
-     * 
+     *
      * @example
-     * 
+     *
      *  ->setMultiple('delete' => array ('title' => "Delete", 'route' => 'route_to_delete' ));
-     * 
+     *
      * @param array $multiple
-     * 
+     *
      * @return \Ali\DatatableBundle\Util\Datatable
      */
     public function setMultiple(array $multiple)
@@ -546,7 +547,7 @@ class Datatable
 
     /**
      * get global configuration ( read it from config.yml under ali_datatable)
-     * 
+     *
      * @return array
      */
     public function getConfiguration()
@@ -556,7 +557,7 @@ class Datatable
 
     /**
      * get search field
-     * 
+     *
      * @return array
      */
     public function getSearchFields()
@@ -566,13 +567,13 @@ class Datatable
 
     /**
      * set search fields
-     * 
-     * @example 
-     * 
+     *
+     * @example
+     *
      *      ->setSearchFields(array(0,2,5))
-     * 
+     *
      * @param array $search_fields
-     * 
+     *
      * @return \Ali\DatatableBundle\Util\Datatable
      */
     public function setSearchFields(array $search_fields)
@@ -581,4 +582,21 @@ class Datatable
         return $this;
     }
 
+    /**
+     * @param EntityManager $entityManager
+     */
+    public function setEntityManager(EntityManager $entityManager)
+    {
+        $this->_em = $entityManager;
+        // We should update the querybuilder to
+        $this->_queryBuilder = new DoctrineBuilder($this->_container, $this->getEntityManager());
+    }
+
+    /**
+     * @return EntityManager
+     */
+    public function getEntityManager()
+    {
+        return $this->_em;
+    }
 }

--- a/Util/Factory/Query/DoctrineBuilder.php
+++ b/Util/Factory/Query/DoctrineBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Ali\DatatableBundle\Util\Factory\Query;
 
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Expr\Join;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -55,21 +56,21 @@ class DoctrineBuilder implements QueryInterface
     protected $search = FALSE;
 
     /**
-     * class constructor 
-     * 
-     * @param ContainerInterface $container 
+     * class constructor
+     *
+     * @param ContainerInterface $container
      */
-    public function __construct(ContainerInterface $container)
+    public function __construct(ContainerInterface $container, EntityManager $entityManager)
     {
         $this->container    = $container;
-        $this->em           = $this->container->get('doctrine.orm.entity_manager');
+        $this->em           = $entityManager;
         $this->request      = $this->container->get('request');
         $this->queryBuilder = $this->em->createQueryBuilder();
     }
 
     /**
      * get the search dql
-     * 
+     *
      * @return string
      */
     protected function _addSearch(\Doctrine\ORM\QueryBuilder $queryBuilder)
@@ -113,20 +114,20 @@ class DoctrineBuilder implements QueryInterface
 
     /**
      * add join
-     * 
+     *
      * @example:
-     *      ->setJoin( 
-     *              'r.event', 
-     *              'e', 
-     *              \Doctrine\ORM\Query\Expr\Join::INNER_JOIN, 
-     *              'e.name like %test%') 
-     * 
+     *      ->setJoin(
+     *              'r.event',
+     *              'e',
+     *              \Doctrine\ORM\Query\Expr\Join::INNER_JOIN,
+     *              'e.name like %test%')
+     *
      * @param string $join_field
      * @param string $alias
      * @param string $type
      * @param string $cond
-     * 
-     * @return Datatable 
+     *
+     * @return Datatable
      */
     public function addJoin($join_field, $alias, $type = Join::INNER_JOIN, $cond = '')
     {
@@ -142,8 +143,8 @@ class DoctrineBuilder implements QueryInterface
 
     /**
      * get total records
-     * 
-     * @return integer 
+     *
+     * @return integer
      */
     public function getTotalRecords()
     {
@@ -167,10 +168,10 @@ class DoctrineBuilder implements QueryInterface
 
     /**
      * get data
-     * 
+     *
      * @param int $hydration_mode
-     * 
-     * @return array 
+     *
+     * @return array
      */
     public function getData($hydration_mode)
     {
@@ -206,7 +207,7 @@ class DoctrineBuilder implements QueryInterface
 
         // add search
         $this->_addSearch($qb);
-        
+
         // get results and process data formatting
         $query          = $qb->getQuery();
         $iDisplayLength = (int) $request->get('iDisplayLength');
@@ -242,7 +243,7 @@ class DoctrineBuilder implements QueryInterface
 
     /**
      * get entity name
-     * 
+     *
      * @return string
      */
     public function getEntityName()
@@ -252,7 +253,7 @@ class DoctrineBuilder implements QueryInterface
 
     /**
      * get entity alias
-     * 
+     *
      * @return string
      */
     public function getEntityAlias()
@@ -262,7 +263,7 @@ class DoctrineBuilder implements QueryInterface
 
     /**
      * get fields
-     * 
+     *
      * @return array
      */
     public function getFields()
@@ -282,7 +283,7 @@ class DoctrineBuilder implements QueryInterface
 
     /**
      * get order type
-     * 
+     *
      * @return string
      */
     public function getOrderType()
@@ -292,7 +293,7 @@ class DoctrineBuilder implements QueryInterface
 
     /**
      * get doctrine query builder
-     * 
+     *
      * @return \Doctrine\ORM\QueryBuilder
      */
     public function getDoctrineQueryBuilder()
@@ -302,11 +303,11 @@ class DoctrineBuilder implements QueryInterface
 
     /**
      * set entity
-     * 
+     *
      * @param type $entity_name
      * @param type $entity_alias
-     * 
-     * @return Datatable 
+     *
+     * @return Datatable
      */
     public function setEntity($entity_name, $entity_alias)
     {
@@ -318,10 +319,10 @@ class DoctrineBuilder implements QueryInterface
 
     /**
      * set fields
-     * 
+     *
      * @param array $fields
-     * 
-     * @return Datatable 
+     *
+     * @return Datatable
      */
     public function setFields(array $fields)
     {
@@ -332,11 +333,11 @@ class DoctrineBuilder implements QueryInterface
 
     /**
      * set order
-     * 
+     *
      * @param type $order_field
      * @param type $order_type
-     * 
-     * @return Datatable 
+     *
+     * @return Datatable
      */
     public function setOrder($order_field, $order_type)
     {
@@ -348,10 +349,10 @@ class DoctrineBuilder implements QueryInterface
 
     /**
      * set fixed data
-     * 
+     *
      * @param type $data
-     * 
-     * @return Datatable 
+     *
+     * @return Datatable
      */
     public function setFixedData($data)
     {
@@ -361,11 +362,11 @@ class DoctrineBuilder implements QueryInterface
 
     /**
      * set query where
-     * 
+     *
      * @param string $where
      * @param array  $params
-     * 
-     * @return Datatable 
+     *
+     * @return Datatable
      */
     public function setWhere($where, array $params = array())
     {
@@ -376,10 +377,10 @@ class DoctrineBuilder implements QueryInterface
 
     /**
      * set query group
-     * 
+     *
      * @param string $group
-     * 
-     * @return Datatable 
+     *
+     * @return Datatable
      */
     public function setGroupBy($group)
     {
@@ -389,9 +390,9 @@ class DoctrineBuilder implements QueryInterface
 
     /**
      * set search
-     * 
+     *
      * @param bool $search
-     * 
+     *
      * @return Datatable
      */
     public function setSearch($search)
@@ -402,10 +403,10 @@ class DoctrineBuilder implements QueryInterface
 
     /**
      * set doctrine query builder
-     * 
+     *
      * @param \Doctrine\ORM\QueryBuilder $queryBuilder
-     * 
-     * @return DoctrineBuilder 
+     *
+     * @return DoctrineBuilder
      */
     public function setDoctrineQueryBuilder(\Doctrine\ORM\QueryBuilder $queryBuilder)
     {


### PR DESCRIPTION
fixes #107 

```
$datatable = $this->container->get('datatable');
$datatable->setEntityManager($this->container->get(doctrine.orm.my_entity_manager))
          ->setFields(array(/* */));
```