### PR TITLE
Set Em Service dependency to real config default

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -7,7 +7,7 @@ services:
         arguments: [ @service_container ]
         scope: prototype
         calls:
-            - [setEntityManager, ['@doctrine.orm.default_entity_manager']]
+            - [setEntityManager, ['@doctrine.orm.entity_manager']]
             
     datatable.twig.extension:
         class: Ali\DatatableBundle\Twig\Extension\AliDatatableExtension


### PR DESCRIPTION
The "doctrine.orm.default_entity_manager" requires an em with name "default". But this must not everytime be the case.