### PR TITLE
Fix incorrect script container ID

### DIFF
--- a/Resources/views/Internal/container.html.twig
+++ b/Resources/views/Internal/container.html.twig
@@ -1,1 +1,1 @@
-<script id="ali-datatable-scripts" type="text/javascript"></script>
+<script id="alidatatable-scripts" type="text/javascript"></script>


### PR DESCRIPTION
Looking at [this line in the DatatableListener](https://github.com/AliHichem/AliDatatableBundle/blob/master/EventListener/DatatableListener.php#L68) it seems we should be able to control the position of the injected JS, e.g. before our own template scripts so we can manipulate the datatable after it has been initialized:
```twig
{% block javascripts %}
  {{ parent() }}
  {{ include('AliDatatableBundle:Internal:container.html.twig') }}
  <script type="text/javascript">
    $(document).ready(function () {
      var opts = $('#dta-unique-id_1').dataTable().fnSettings();
      console.log(opts); // do whatever
    });
  </script>
{% endblock %}
```
However the ID used in the template and the event listener are mismatched, which breaks this use-case.