### PR TITLE
array_walk() many times create problem

### DIFF
--- a/EventListener/DatatableListener.php
+++ b/EventListener/DatatableListener.php
@@ -66,7 +66,7 @@ class DatatableListener implements EventSubscriberInterface
         $session       = $request->getSession();
         $dom           = '<script id="alidatatable-scripts" type="text/javascript">';
         $pos_container = strripos($content, 'alidatatable-scripts');
-        $sess_dta      = $session->get('datatable');
+        $sess_dta      = $session->get('datatable',[]);
         $dta_script    = null;
         array_walk($sess_dta, function(&$part, &$key) {
             $part = trim(preg_replace('/\s\s+/', ' ', $part));


### PR DESCRIPTION
If we don't get session variable `datatable`, that time it return null so, set default value empty array instead of null.