### PR TITLE
`isMasterRequest` was introduced in 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "require": {
         "php": ">=5.3.0",
 	"twig/twig": ">=1.8,<2.0-dev",
-        "doctrine/orm": "~2.4@stable,>=2.1,<=2.5"
+        "doctrine/orm": "~2.4@stable,>=2.1,<=2.5",
+        "symfony/http-kernel": "~2.4"
     },
     "target-dir": "Ali/DatatableBundle",
     "autoload": {


### PR DESCRIPTION
Method `isMasterRequest` for `KernelEvent` was introduced in version 2.4. https://github.com/symfony/HttpKernel/blob/2.4/Event/KernelEvent.php

Due you are using this method you should add this constraint. Otherwise people will get error like #127 