### PR TITLE
Corrected messages.es.yml translation file

### DIFF
--- a/Resources/translations/messages.es.yml
+++ b/Resources/translations/messages.es.yml
@@ -1,21 +1,21 @@
 ali:
     common:
-        action: Acciones
-        confirm_delete: "Est seguro(a) que desea eliminar esta entrada?"
-        delete: borrar
-        edit: editar
+        action: "Acciones"
+        confirm_delete: "¿Está seguro de que desea eliminar este elemento?"
+        delete: "borrar"
+        edit: "editar"
         no_action: "-"
-        sFirst: Primera
-        sInfo: "Mostrando entradas _START_ a _END_ de _TOTAL_"
-        sInfoEmpty: "Mostrando 0 de 0 entradas"
-        sInfoFiltered: "(filtradas de un total de _MAX_ entradas)"
+        sProcessing: "Cargando..."
+        sLengthMenu: "Mostrar _MENU_ registros"
+        sZeroRecords: "No se encontraron resultados"
+        sInfo: "Mostrando registros del _START_ al _END_ de un total de _TOTAL_ registros"
+        sInfoEmpty: "Mostrando registros del 0 al 0 de un total de 0 registros"
+        sInfoFiltered: "(filtrado de un total de _MAX_ registros)"
         sInfoPostFix: ""
-        sLast: ltima
-        sLengthMenu: "Mostrar _MENU_ entradas"
-        sLoadingRecords: ""
-        sNext: Siguiente
-        sPrevious: Anterior
-        sProcessing: Cargando...
         sSearch: "Buscar:"
-        sZeroRecords: "No se encontr ninguna entrada"
-        search: "búsqueda"
+        sLoadingRecords: ""
+        sFirst: "Primero"
+        sPrevious: "Anterior"  
+        sNext: "Siguiente"
+        sLast: "Último"
+        search: "Filtrar"


### PR DESCRIPTION
Corrected the Spanish translation.
I've actually used the 'official' Spanish translation from dataTables website:
http://datatables.net/plug-ins/i18n/Spanish

Full list of translations:
http://datatables.net/plug-ins/i18n/