### PR TITLE
Dutch translation fix (minor)

### DIFF
--- a/Resources/translations/messages.nl.yml
+++ b/Resources/translations/messages.nl.yml
@@ -8,7 +8,7 @@ ali:
         sProcessing: "Bezig..."
         sLengthMenu: "_MENU_ resultaten weergeven"
         sZeroRecords: "Geen resultaten om weer te geven"
-        sInfo: "Weergave van _START_ tot _END_ van _TOTAL_ resultaten"
+        sInfo: "Weergave van _START_ t/m _END_ van _TOTAL_ resultaten"
         sInfoEmpty: "Weergaven van 0 tot 0 van 0 resultaten"
         sInfoFiltered: "(gefilterd uit _MAX_ resultaten)"
         sInfoPostFix: ""

--- a/Resources/translations/messages.nl.yml
+++ b/Resources/translations/messages.nl.yml
@@ -19,4 +19,3 @@ ali:
         sNext: "Volgende"
         sLast: "Laatste"
         search: "Zoek"
-        


### PR DESCRIPTION
in Dutch the meaning of `tot` (till) is exclusive, the meaning of `t/m` which is an abbreviation for `tot en met` is including.
see google translate for more information if wanted:
translation of `tot en met`: https://translate.google.com/#nl/en/tot%20en%20met
translation of `tot`: https://translate.google.com/#nl/en/tot